### PR TITLE
feat: retry extra args and msg value estimation

### DIFF
--- a/.changeset/empty-scissors-warn.md
+++ b/.changeset/empty-scissors-warn.md
@@ -1,0 +1,5 @@
+---
+"@folks-finance/xchain-sdk": patch
+---
+
+Added retry and reverse msg value estimation considering bridge router balance

--- a/.changeset/violet-starfishes-stare.md
+++ b/.changeset/violet-starfishes-stare.md
@@ -1,0 +1,5 @@
+---
+"@folks-finance/xchain-sdk": patch
+---
+
+Added retry extra args completion with gas limit estimation

--- a/src/chains/evm/common/types/gmp.ts
+++ b/src/chains/evm/common/types/gmp.ts
@@ -41,11 +41,3 @@ export type MessageReceived = {
   returnAdapterId: AdapterType;
   returnGasLimit: bigint;
 };
-
-export type MsgValueEstimationArgs = {
-  folksChainId: FolksChainId;
-  accountId: AccountId;
-  poolId: number;
-  returnAdapterId: AdapterType;
-  returnGasLimit: bigint;
-};

--- a/src/chains/evm/common/types/gmp.ts
+++ b/src/chains/evm/common/types/gmp.ts
@@ -22,6 +22,8 @@ export type RetryMessageExtraArgs = {
   returnGasLimit: bigint;
 };
 
+export type RetryMessageExtraArgsParams = Partial<Omit<RetryMessageExtraArgs, "returnGasLimit">> | undefined;
+
 export type ReverseMessageExtraArgs = {
   accountId: AccountId;
   returnAdapterId: AdapterType;
@@ -36,6 +38,14 @@ export type MessageReceived = {
   sourceAddress: GenericAddress;
   handler: GenericAddress;
   payload: Hex;
+  returnAdapterId: AdapterType;
+  returnGasLimit: bigint;
+};
+
+export type MsgValueEstimationArgs = {
+  folksChainId: FolksChainId;
+  accountId: AccountId;
+  poolId: number;
   returnAdapterId: AdapterType;
   returnGasLimit: bigint;
 };

--- a/src/chains/evm/hub/utils/message.ts
+++ b/src/chains/evm/hub/utils/message.ts
@@ -1,3 +1,4 @@
+import { RECEIVE_TOKEN_ACTIONS } from "../../../../common/constants/message.js";
 import { MessageDirection } from "../../../../common/types/gmp.js";
 import { Action, AdapterType } from "../../../../common/types/message.js";
 import { getSpokeChain, getSpokeTokenData } from "../../../../common/utils/chain.js";
@@ -10,70 +11,154 @@ import type { NetworkType } from "../../../../common/types/chain.js";
 import type {
   MessageBuilderParams,
   Payload,
+  ReceiveTokenAction,
   ReversibleHubAction,
   SendTokenExtraArgs,
   SendTokenMessageData,
 } from "../../../../common/types/message.js";
 import type {
   MessageReceived,
+  MsgValueEstimationArgs,
+  RetryMessageExtraArgs,
+  RetryMessageExtraArgsParams,
   ReverseMessageExtraArgs,
   ReverseMessageExtraArgsParams,
 } from "../../common/types/gmp.js";
 import type { HubChain } from "../types/chain.js";
 
-export async function getHubReverseMessageExtraArgs(
+export async function getHubRetryMessageExtraArgsAndValue(
   hubChain: HubChain,
   network: NetworkType,
   userAddress: GenericAddress,
   message: MessageReceived,
-  extraArgs: ReverseMessageExtraArgsParams,
+  extraArgsParams: RetryMessageExtraArgsParams,
   payload: Payload,
-): Promise<ReverseMessageExtraArgs | undefined> {
-  if (!extraArgs) return undefined;
-
+): Promise<{
+  msgValueEstimationArgs: MsgValueEstimationArgs;
+  extraArgs: RetryMessageExtraArgs;
+}> {
+  const returnAdapterId = extraArgsParams?.returnAdapterId ?? message.returnAdapterId;
   const { accountId, action, data } = payload;
+
+  // @ts-expect-error: ts(2345)
+  if (!RECEIVE_TOKEN_ACTIONS.includes(action)) return { value: 0n, extraArgs: { returnAdapterId, returnGasLimit: 0n } };
+  const payloadData = decodeMessagePayloadData(action as ReceiveTokenAction, data);
+
+  const folksTokenId = getFolksTokenIdFromPool(payloadData.poolId);
+
+  const spokeChain = getSpokeChain(payloadData.receiverFolksChainId, network);
+  const spokeTokenData = getSpokeTokenData(spokeChain, folksTokenId);
+
+  const returnData: SendTokenMessageData = {
+    amount: payloadData.amount,
+  };
+  const returnExtraArgs: SendTokenExtraArgs = {
+    folksTokenId,
+    token: spokeTokenData.token,
+    recipient: spokeTokenData.spokeAddress,
+    amount: payloadData.amount,
+  };
+  const returnMessageBuilderParams: MessageBuilderParams = {
+    userAddress,
+    accountId,
+    adapters: {
+      adapterId: AdapterType.HUB,
+      returnAdapterId: extraArgsParams?.returnAdapterId ?? message.returnAdapterId,
+    },
+    action: Action.SendToken,
+    sender: hubChain.hubAddress,
+    destinationChainId: payloadData.receiverFolksChainId,
+    handler: spokeTokenData.spokeAddress,
+    data: returnData,
+    extraArgs: returnExtraArgs,
+  };
+  const returnGasLimit = await estimateAdapterReceiveGasLimit(
+    hubChain.folksChainId,
+    payloadData.receiverFolksChainId,
+    FolksCore.getEVMProvider(payloadData.receiverFolksChainId),
+    network,
+    MessageDirection.HubToSpoke,
+    returnMessageBuilderParams,
+  );
+
   return {
-    returnAdapterId: extraArgs.returnAdapterId ?? message.returnAdapterId,
-    accountId: extraArgs.accountId ?? accountId,
-    returnGasLimit: await (async () => {
-      const payloadData = decodeMessagePayloadData(action as ReversibleHubAction, data);
+    msgValueEstimationArgs: {
+      folksChainId: payloadData.receiverFolksChainId,
+      accountId,
+      poolId: payloadData.poolId,
+      returnAdapterId,
+      returnGasLimit,
+    },
+    extraArgs: { returnAdapterId, returnGasLimit },
+  };
+}
 
-      const folksTokenId = getFolksTokenIdFromPool(payloadData.poolId);
+export async function getHubReverseMessageExtraArgsAndValue(
+  hubChain: HubChain,
+  network: NetworkType,
+  userAddress: GenericAddress,
+  message: MessageReceived,
+  extraArgsParams: ReverseMessageExtraArgsParams,
+  payload: Payload,
+): Promise<{
+  msgValueEstimationArgs: MsgValueEstimationArgs;
+  extraArgs: ReverseMessageExtraArgs;
+}> {
+  const { action, data } = payload;
+  const payloadData = decodeMessagePayloadData(action as ReversibleHubAction, data);
 
-      const spokeChain = getSpokeChain(message.sourceChainId, network);
-      const spokeTokenData = getSpokeTokenData(spokeChain, folksTokenId);
+  const returnAdapterId = extraArgsParams?.returnAdapterId ?? message.returnAdapterId;
+  const accountId = extraArgsParams?.accountId ?? payload.accountId;
 
-      const returnData: SendTokenMessageData = {
-        amount: payloadData.amount,
-      };
-      const returnExtraArgs: SendTokenExtraArgs = {
-        folksTokenId,
-        token: spokeTokenData.token,
-        recipient: spokeTokenData.spokeAddress,
-        amount: payloadData.amount,
-      };
-      const returnMessageBuilderParams: MessageBuilderParams = {
-        userAddress,
-        accountId,
-        adapters: {
-          adapterId: AdapterType.HUB,
-          returnAdapterId: extraArgs.returnAdapterId ?? message.returnAdapterId,
-        },
-        action: Action.SendToken,
-        sender: hubChain.hubAddress,
-        destinationChainId: message.sourceChainId,
-        handler: spokeTokenData.spokeAddress,
-        data: returnData,
-        extraArgs: returnExtraArgs,
-      };
-      return await estimateAdapterReceiveGasLimit(
-        hubChain.folksChainId,
-        message.sourceChainId,
-        FolksCore.getEVMProvider(message.sourceChainId),
-        network,
-        MessageDirection.HubToSpoke,
-        returnMessageBuilderParams,
-      );
-    })(),
+  const folksTokenId = getFolksTokenIdFromPool(payloadData.poolId);
+
+  const spokeChain = getSpokeChain(message.sourceChainId, network);
+  const spokeTokenData = getSpokeTokenData(spokeChain, folksTokenId);
+
+  const returnData: SendTokenMessageData = {
+    amount: payloadData.amount,
+  };
+  const returnExtraArgs: SendTokenExtraArgs = {
+    folksTokenId,
+    token: spokeTokenData.token,
+    recipient: spokeTokenData.spokeAddress,
+    amount: payloadData.amount,
+  };
+  const returnMessageBuilderParams: MessageBuilderParams = {
+    userAddress,
+    accountId,
+    adapters: {
+      adapterId: AdapterType.HUB,
+      returnAdapterId,
+    },
+    action: Action.SendToken,
+    sender: hubChain.hubAddress,
+    destinationChainId: message.sourceChainId,
+    handler: spokeTokenData.spokeAddress,
+    data: returnData,
+    extraArgs: returnExtraArgs,
+  };
+  const returnGasLimit = await estimateAdapterReceiveGasLimit(
+    hubChain.folksChainId,
+    message.sourceChainId,
+    FolksCore.getEVMProvider(message.sourceChainId),
+    network,
+    MessageDirection.HubToSpoke,
+    returnMessageBuilderParams,
+  );
+
+  return {
+    msgValueEstimationArgs: {
+      folksChainId: message.sourceChainId,
+      accountId,
+      poolId: payloadData.poolId,
+      returnAdapterId,
+      returnGasLimit,
+    },
+    extraArgs: {
+      accountId,
+      returnAdapterId,
+      returnGasLimit,
+    },
   };
 }

--- a/src/common/constants/message.ts
+++ b/src/common/constants/message.ts
@@ -6,3 +6,7 @@ export const FINALITY = {
 } as const;
 
 export const REVERSIBLE_HUB_ACTIONS = [Action.CreateLoanAndDeposit, Action.Deposit, Action.Repay] as const;
+
+export const SEND_TOKEN_ACTIONS = [Action.CreateLoanAndDeposit, Action.Deposit, Action.Repay] as const;
+export const RECEIVE_TOKEN_ACTIONS = [Action.Withdraw, Action.Borrow] as const;
+export const HUB_ACTIONS = [Action.DepositFToken, Action.WithdrawFToken, Action.Liquidate, Action.SendToken] as const;

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -3,7 +3,13 @@ import type { FolksChainId } from "./chain.js";
 import type { AccountId, LoanId, LoanName, Nonce } from "./lending.js";
 import type { LoanTypeId } from "./module.js";
 import type { FolksTokenId, FolksSpokeTokenType } from "./token.js";
-import type { FINALITY, REVERSIBLE_HUB_ACTIONS } from "../constants/message.js";
+import type {
+  FINALITY,
+  HUB_ACTIONS,
+  RECEIVE_TOKEN_ACTIONS,
+  REVERSIBLE_HUB_ACTIONS,
+  SEND_TOKEN_ACTIONS,
+} from "../constants/message.js";
 import type { Hex } from "viem";
 
 export enum AdapterType {
@@ -38,12 +44,9 @@ export enum Action {
   SendToken,
 }
 
-export type SendTokenAction = Extract<Action, Action.CreateLoanAndDeposit | Action.Deposit | Action.Repay>;
-export type ReceiveTokenAction = Extract<Action, Action.Withdraw | Action.Borrow>;
-export type HubAction = Extract<
-  Action,
-  Action.DepositFToken | Action.WithdrawFToken | Action.Liquidate | Action.SendToken
->;
+export type SendTokenAction = Extract<Action, (typeof SEND_TOKEN_ACTIONS)[number]>;
+export type ReceiveTokenAction = Extract<Action, (typeof RECEIVE_TOKEN_ACTIONS)[number]>;
+export type HubAction = Extract<Action, (typeof HUB_ACTIONS)[number]>;
 
 export type ReversibleHubAction = Extract<Action, (typeof REVERSIBLE_HUB_ACTIONS)[number]>;
 

--- a/src/common/utils/messages.ts
+++ b/src/common/utils/messages.ts
@@ -21,7 +21,7 @@ import {
 import { getHubChainAdapterAddress } from "../../chains/evm/hub/utils/chain.js";
 import { exhaustiveCheck } from "../../utils/exhaustive-check.js";
 import { BYTES32_LENGTH, BYTES4_LENGTH, UINT16_LENGTH, UINT256_LENGTH, UINT8_LENGTH } from "../constants/bytes.js";
-import { REVERSIBLE_HUB_ACTIONS } from "../constants/message.js";
+import { REVERSIBLE_HUB_ACTIONS, SEND_TOKEN_ACTIONS } from "../constants/message.js";
 import { ChainType } from "../types/chain.js";
 import { MessageDirection } from "../types/gmp.js";
 import { Action, AdapterType } from "../types/message.js";
@@ -262,6 +262,17 @@ export function isReversibleAction(action: Action, messageDirection: MessageDire
 export function assertReversibleAction(action: Action, messageDirection: MessageDirection) {
   if (!isReversibleAction(action, messageDirection))
     throw new Error(`Action ${action} is not reversible for message direction ${messageDirection}`);
+}
+
+export function isRetryableAction(action: Action, messageDirection: MessageDirection) {
+  if (messageDirection === MessageDirection.HubToSpoke) return true;
+  // @ts-expect-error: ts(2345)
+  return SEND_TOKEN_ACTIONS.includes(action);
+}
+
+export function assertRetryableAction(action: Action, messageDirection: MessageDirection) {
+  if (!isRetryableAction(action, messageDirection))
+    throw new Error(`Action ${action} is not retryable for message direction ${messageDirection}`);
 }
 
 export function decodeMessagePayload(payload: Hex): Payload {

--- a/src/common/utils/messages.ts
+++ b/src/common/utils/messages.ts
@@ -255,8 +255,7 @@ export async function waitOperationIds(
 
 export function isReversibleAction(action: Action, messageDirection: MessageDirection) {
   // @ts-expect-error: ts(2345)
-  if (messageDirection === MessageDirection.HubToSpoke) return REVERSIBLE_HUB_ACTIONS.includes(action);
-  return false;
+  return messageDirection === MessageDirection.HubToSpoke && REVERSIBLE_HUB_ACTIONS.includes(action);
 }
 
 export function assertReversibleAction(action: Action, messageDirection: MessageDirection) {
@@ -265,9 +264,8 @@ export function assertReversibleAction(action: Action, messageDirection: Message
 }
 
 export function isRetryableAction(action: Action, messageDirection: MessageDirection) {
-  if (messageDirection === MessageDirection.HubToSpoke) return true;
   // @ts-expect-error: ts(2345)
-  return SEND_TOKEN_ACTIONS.includes(action);
+  return messageDirection === MessageDirection.HubToSpoke || SEND_TOKEN_ACTIONS.includes(action);
 }
 
 export function assertRetryableAction(action: Action, messageDirection: MessageDirection) {


### PR DESCRIPTION
Resolve #141 
Resolve #156 
Resolve:
> Should subtract from msgValue the existing account's bridge router balanace for retry when a return message is needed
> Should subtract from msgValue the existing account's bridge router balanace for reverse

- Added completion of retry extraArgs when missing
- Added check on retryable actions
- Refactored actions types
- Added utils to calc requires msg value